### PR TITLE
feat: add option to skip trigger if field is empty

### DIFF
--- a/class-contact-updated-trigger.php
+++ b/class-contact-updated-trigger.php
@@ -178,6 +178,21 @@ class Contact_Updated_Trigger extends BaseTrigger {
 					'value'      => 'specific',
 				),
 			),
+			'field_empty'  => array(
+				'type'       => 'radio',
+				'label'      => __( 'Can the field be empty ?', 'fluentcampaign-pro' ),
+				'options' => array(
+					array(
+						'id'    => 'yes',
+						'title' => __( 'Yes', 'fluentcampaign-pro' ),
+					),
+					array(
+						'id'    => 'no',
+						'title' => __( 'No', 'fluentcampaign-pro' ),
+					),
+				),
+				'help'       => __( 'If the field can be empty, the automation will run. Otherwise it will be skipped.', 'fluentcampaign-pro' ),
+			),
 			'run_multiple' => array(
 				'type'        => 'yes_no_check',
 				'label'       => '',
@@ -240,6 +255,13 @@ class Contact_Updated_Trigger extends BaseTrigger {
 		if ( 'specific' === $update_type && Arr::get( $funnel->conditions, 'field_value' ) !== $updated_data[ $field ] ) {
 			return false;
 		}
+
+		$field_empty = Arr::get( $funnel->conditions, 'field_empty');
+		
+		// Check if the updated data field is empty
+		if ( 'no' === $field_empty && empty( $updated_data[ $field ] )) {
+			return false;
+		} 
 
 		if ( $subscriber && FunnelHelper::ifAlreadyInFunnel( $funnel->id, $subscriber->id ) ) {
 			if ( 'yes' === Arr::get( $funnel->conditions, 'run_multiple' ) ) {

--- a/class-field-updated-trigger.php
+++ b/class-field-updated-trigger.php
@@ -136,6 +136,21 @@ class Field_Updated_Trigger extends BaseTrigger {
 					'value'      => 'specific',
 				),
 			),
+			'field_empty'  => array(
+				'type'       => 'radio',
+				'label'      => __( 'Can the field be empty ?', 'fluentcampaign-pro' ),
+				'options' => array(
+					array(
+						'id'    => 'yes',
+						'title' => __( 'Yes', 'fluentcampaign-pro' ),
+					),
+					array(
+						'id'    => 'no',
+						'title' => __( 'No', 'fluentcampaign-pro' ),
+					),
+				),
+				'help'       => __( 'If the field can be empty, the automation will run. Otherwise it will be skipped.', 'fluentcampaign-pro' ),
+			),
 			'run_multiple' => array(
 				'type'        => 'yes_no_check',
 				'label'       => '',
@@ -201,6 +216,13 @@ class Field_Updated_Trigger extends BaseTrigger {
 		if ( 'specific' === $update_type && Arr::get( $funnel->conditions, 'field_value' ) !== $updated_data[ $field ] ) {
 			return false;
 		}
+
+		$field_empty = Arr::get( $funnel->conditions, 'field_empty');
+		
+		// Check if the updated data field is empty
+		if ( 'no' === $field_empty && empty( $updated_data[ $field ] )) {
+			return false;
+		} 
 
 		// check run_only_once.
 		if ( $subscriber && FunnelHelper::ifAlreadyInFunnel( $funnel->id, $subscriber->id ) ) {


### PR DESCRIPTION
### What does this PR do?

This PR introduces a new setting that allows the user to control the behavior of the trigger when the related field is empty.

### Why is this needed?

Previously, when using "Any value" as a condition, the trigger could fire even if the field was empty. This led to unexpected automation executions.

With this update, users can now decide:
- ✅ Whether the automation should continue even if the field is empty
- ❌ Or skip the trigger if no value is present

### How it works

A new radio option has been added to the trigger settings:
> **Can the field be empty ?**
>  ❍ yes ❍ no

If 'no', the trigger will be skipped when the field is empty.

### Notes

- Default behavior remains unchanged