### PR TITLE
Fix type comparison issue for field value matching

### DIFF
--- a/class-field-updated-trigger.php
+++ b/class-field-updated-trigger.php
@@ -198,8 +198,15 @@ class Field_Updated_Trigger extends BaseTrigger {
 		$update_type = Arr::get( $funnel->conditions, 'update_type' );
 
 		// Check if we're looking for a specific value match.
-		if ( 'specific' === $update_type && Arr::get( $funnel->conditions, 'field_value' ) !== $updated_data[ $field ] ) {
-			return false;
+		if ( 'specific' === $update_type ) {
+			// Cast both values to strings to ensure consistent comparison
+			// This handles cases where the field value might be an integer
+			$expected_value = (string) Arr::get( $funnel->conditions, 'field_value' );
+			$actual_value   = (string) $updated_data[ $field ];
+			
+			if ( $expected_value !== $actual_value ) {
+				return false;
+			}
 		}
 
 		// check run_only_once.


### PR DESCRIPTION
## Summary
- Fixed strict type comparison that prevented "Specific Value" trigger from working when field values have different types
- Cast both expected and actual values to strings before comparison
- Resolves issue where WP Fusion sends integer values (e.g., `int(1)` for checkbox fields) while FluentCRM expects string values

## Problem
When using WP Fusion's WooCommerce Email Optin with checkbox field type, it sends `int(1)` but the FluentCRM Field Updated Trigger expects string values and uses strict comparison (`\!==`). This caused the "Specific Value" trigger condition to never match.

## Solution
Cast both values to strings before comparison to ensure type consistency while maintaining strict comparison for the actual values.

## Test plan
- [x] Test with checkbox fields that send integer values
- [x] Test with text fields that send string values  
- [x] Verify "Any Value" trigger still works correctly
- [x] Verify "Specific Value" trigger now works with both string and integer field values

Fixes support ticket #35087

🤖 Generated with [Claude Code](https://claude.ai/code)